### PR TITLE
Update scan-dirs to no longer throw

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare dotnet
+        uses: xt0rted/setup-dotnet@v1.5.0
+
+      - name: Prepare Clojure CLR
+        run: |
+          dotnet tool install --global Clojure.Main --version 1.12.0-alpha10
+          dotnet tool install --global Clojure.Cljr --version 0.1.0-alpha5
+
+      - name: Run cljr tests
+        run: cljr -X:test

--- a/src/main/clojure/clojure/tools/namespace/dir.clj
+++ b/src/main/clojure/clojure/tools/namespace/dir.clj
@@ -27,8 +27,13 @@
        (mapcat #(find/find-sources-in-dir % platform))
        ))                                          ;;; ditto:  (map #(.getCanonicalFile ^File %))
 
+(defn- modified-since-tracked? [tracker file]
+  (if-let [time (::time tracker)]
+    (DateTime/op_LessThan time (.LastWriteTimeUtc ^FileSystemInfo file))
+    true))
+
 (defn- modified-files [tracker files]
-  (filter #(DateTime/op_LessThan ^DateTime (::time tracker 0) (.LastWriteTimeUTC ^FileSystemInfo %)) files))         ;;; (.lastModified ^File %)
+  (filter (partial modified-since-tracked? tracker) files))         ;;; (.lastModified ^File %)
 
 (defn- deleted-files [tracker files]
   (set/difference (::files tracker #{}) (set files)))
@@ -129,6 +134,3 @@
     (instance? DirectoryInfo x) x
 	(string? x) (DirectoryInfo. ^String x)
 	:default (DirectoryInfo. (str x))))
-	
-	
-  

--- a/src/test/clojure/clojure/tools/namespace/dir_test.clj
+++ b/src/test/clojure/clojure/tools/namespace/dir_test.clj
@@ -4,6 +4,17 @@
             [clojure.tools.namespace.dir :as dir])
   #_(:import
    (java.io File)))
+
+(defmacro is-not-thrown? [& body]
+  `(try
+     ~@body
+     (is true "No exception thrown")
+     (catch Exception e#
+       (is false (str "Expected no exception, but got: " (.GetType e#) ": " (.-Message e#))))))
+
+(deftest scan-dirs-does-not-throw
+  (is-not-thrown? (dir/scan-dirs {})))
+
 ;;; I don't know what the equivalent test would be for .Net.
 #_(defn- make-symbolic-link
   "Reflectively calls java.nio.file.Files/createSymbolicLink on two


### PR DESCRIPTION
- Updated `scan-dirs` to no longer throw when invoked
- Added GitHub test workflow
